### PR TITLE
Update README.md with valid link to demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ After install, search for the top 10 similar virus in Chimpanzee chromosome 7:
 cp falcon/scripts/DownloadViruses.pl .
 perl DownloadViruses.pl
 wget  --trust-server-names -q \
-ftp://ftp.ncbi.nlm.nih.gov/genomes/Pan_troglodytes/CHR_18/ptr_ref_Pan_troglodytes-2.1.4_chr18.fa.gz \
+ftp://ftp.ncbi.nlm.nih.gov/genomes/Pan_troglodytes/CHR_18/ptr_ref_Clint_PTRv2_chr18.fa.gz \
 -O PT18.fa.gz
 gunzip PT18.fa.gz
 ./FALCON -v -n 4 -c 20 -t 10 -l 15 PT18.fa viruses.fa


### PR DESCRIPTION
I noticed that the FTP server mentioned in the README file does not contain the data set file `ptr_ref_Pan_troglodytes-2.1.4_chr18.fa.gz`. It might have been renamed of replaced entirely by new data. Regardless, I tested Falcon with another file in the same directory and it seems to be working.